### PR TITLE
Cleanup/Rewrite of scripts

### DIFF
--- a/scripts/0.start.sh
+++ b/scripts/0.start.sh
@@ -2,15 +2,5 @@
 echo 'Setting up the build envoirment...'
 
 echo 'creating folders...'
-cd ./..
-mkdir ./build
-mkdir ./build/1440k-fdd
-kmdir ./build/1440k-fdd/rootfs
-kmdir ./build/1440k-fdd/rootfs/dev
-kmdir ./build/1440k-fdd/rootfs/etc
-kmdir ./build/1440k-fdd/rootfs/etc/init.d
-kmdir ./build/1440k-fdd/rootfs/proc
-kmdir ./build/1440k-fdd/rootfs/sys
-kmdir ./build/1440k-fdd/rootfs/tmp
-cd ./scripts
+mkdir -pv ../build/{1440k-fdd/rootfs/{dev,etc/init.d,proc,sys,tmp},downloads,working}
 exit

--- a/scripts/1.download.sources.sh
+++ b/scripts/1.download.sources.sh
@@ -1,25 +1,32 @@
 #! /usr/bin/env bash
-echo 'Downloading all the necessary packages...'
 
-cd ./..
-cd ./build
+function download_files(){
+  local url=$1
+  local filename=$2
+  local desc=$3
+
+  if test -f $filename; then
+    echo "File ${filename} already found."
+  else
+    echo "Downloading ${desc}..."
+    wget $url
+    echo "Done downloading ${desc}!"
+  fi
+  echo ''
+}
+
+echo 'Downloading all the necessary packages...'
 echo ''
-echo 'Downloading latest Kernel Release [6..5] ...'
-wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.5.tar.xz
-echo 'done!'
-echo ''
-echo 'Downloading latest Toybox Release [0.8.10] ...'
-wget http://landley.net/toybox/downloads/toybox-0.8.10.tar.gz
-echo 'done!'
-echo ''
-echo 'Downloading musl-cross ...'
-wget https://landley.net/bin/toolchains/latest/i486-linux-musl-cross.tar.xz
-echo 'done!'
-echo ''
-echo 'Downloading Dropbear SSH...'
-wget https://matt.ucc.asn.au/dropbear/releases/dropbear-2022.83.tar.bz2
-echo 'done!'
-echo ''
-echo 'done!'
-cd ./scripts
+
+cd ../build/downloads
+
+download_files https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.5.tar.xz linux-6.5.tar.xz "latest kernel release"
+download_files http://landley.net/toybox/downloads/toybox-0.8.10.tar.gz toybox-0.8.10.tar.gz "toybox"
+download_files https://landley.net/bin/toolchains/latest/i486-linux-musl-cross.tar.xz i486-linux-musl-cross.tar.xz "musl-cross"
+download_files https://musl.libc.org/releases/musl-1.2.4.tar.gz musl-1.2.4.tar.gz "musl"
+download_files https://matt.ucc.asn.au/dropbear/releases/dropbear-2022.83.tar.bz2 dropbear-2022.83.tar.bz2 "dropbear"
+
+echo 'Done with downloads!'
+cd ../../scripts
+
 exit

--- a/scripts/2.unpacking.sources.sh
+++ b/scripts/2.unpacking.sources.sh
@@ -1,38 +1,43 @@
 #! /usr/bin/env bash
 echo 'Unpacking Sources...'
-cd ./../build/
+cd ./../build/working/
 echo ''
 
-echo 'unpacking Linux Kernel Sources...'
-tar -xf ./linux-6.4.12.tar.xz
-mv -r ./linux-6.4.12 ./linux
-echo 'done'
-
-echo ''
-
-echo 'unpacking Toybox Sources...'
-tar -xf toybox-0.8.10.tar.gz
-mv -r ./toybox-0.8.10 ./toybox
-echo 'done'
+echo 'Unpacking Linux Kernel Sources...'
+tar -xf ../downloads/linux-6.5.tar.xz
+mv ./linux-6.5 ./linux
+echo 'Done unpacking Linux!'
 
 echo ''
 
-echo 'unpacking musl-cross Sources...'
-tar -xf i686-linux-musl-cross.tar.xz
-echo 'done'
-echo 'adding musl-cross into /toybox & linux'
-cp -r ./i686-linux-musl-cross ./toybox/
-cp -r ./i686-linux-musl-cross ./linux/
-echo 'done'
+echo 'Unpacking Toybox Sources...'
+tar -xf ../downloads/toybox-0.8.10.tar.gz
+mv ./toybox-0.8.10 ./toybox
+echo 'Done unpacking Toybox!'
 
 echo ''
 
-echo 'unpacking musl Sources...'
-cp ./musl-1.2.4.tar.gz
-tar -xf ./musl-1.2.4.tar.gz
-echo 'done'
+echo 'Unpacking musl-cross Sources...'
+tar -xf ../downloads/i486-linux-musl-cross.tar.xz
+echo 'Done unpacking musl-cross!'
+echo ''
+echo 'Adding musl-cross into /toybox & linux...'
+cp -r ./i486-linux-musl-cross ./toybox/
+cp -r ./i486-linux-musl-cross ./linux/
+echo 'Added!'
 
 echo ''
-cd ./../scripts
+
+echo 'Unpacking musl Sources...'
+tar -xf ../downloads//musl-1.2.4.tar.gz
+echo 'Done unpacking musl source!'
+
+echo 'Unpacking dropbear...'
+tar -xf ../downloads/dropbear-2022.83.tar.bz2
+mv ./dropbear-2022.83 dropbear
+echo 'Done unpacking dropbear!'
+echo ''
+cd ./../../scripts
+echo 'Done unpacking!'
 
 exit

--- a/scripts/3.config.linux-6.5-i486.sh
+++ b/scripts/3.config.linux-6.5-i486.sh
@@ -1,13 +1,22 @@
 #! /usr/bin/env bash
-echo 'building the linux [i486]'
+echo 'Check for config file.'
+if test -f .config; then
+  echo "Copying kernel config."
+  cp -v .config ../build/working/linux/
+fi
+cd ./../build/working/linux/
+if test -f .config; then
+  echo "Kernel config found."
+else
+ echo 'No config found. Generating 6.5-i486 tinyconfig.'
+  make ARCH=x86 tinyconfig
+fi
 
-cd ./../build/linux
-echo 'Generating 6.5-i486.config'
-make ARCH=x86 tinyconfig
 echo 'Please configure the Kernel...'
 make ARCH=x86 menuconfig
-echo 'completed!'
-echo 'ready to compile for i486!'
-cd ./../../scripts
+echo 'Completed!'
+
+echo 'Ready to compile for i486!'
+cd ./../../../scripts
 
 exit

--- a/scripts/4.compile.linux-6.5-i486.sh
+++ b/scripts/4.compile.linux-6.5-i486.sh
@@ -1,19 +1,19 @@
 #! /usr/bin/env bash
-4.compile.linux-kernel.i686.shecho 'building the linux [i486]'
+echo 'Building linux [i486]'
 
-cd ./../build/linux
-echo 'done! Starting to compile...'
+cd ./../build/working/linux
+echo 'Done! Starting to compile...'
 LDFLAGS=--static CROSS_COMPILE=i486-linux-musl-cross/bin/i486-linux-musl- make ARCH=x86 bzImage
-echo 'done!'
+echo 'Done!'
 
 cd ./..
-mkdir ./i486
-mkdir ./i486/config
-mkdir ./i486/config/linux
-mv mv ./linux/arch/x86/boot/bzImage ./linux/
-cd ./../scripts
-echo 'completed!'
-echo 'you can find the Kernel as ./i486/bzImage'
-echo 'your linux configuration has been backed up to ./i486/config/linux'
+mkdir -pv ./i486
+mv ./linux/arch/x86/boot/bzImage ../1440k-fdd
+mv ./linux/.config ../1440k-fdd/syslinux.cfg
+cd ./../../scripts
+
+echo "Completed!"
+echo 'You can find the Kernel at ./build/1440k-fdd/bzImage'
+echo 'Your linux configuration has been backed up to ./build/1440k-fdd/syslinux.cfg'
 
 exit

--- a/scripts/5.config.toybox-0.8.10-i486.sh
+++ b/scripts/5.config.toybox-0.8.10-i486.sh
@@ -1,10 +1,10 @@
 #! /usr/bin/env bash
-echo 'building the toybox [i686]'
+echo 'Building toybox [i686]'
 
-cd ./../build/toybox
+cd ./../build/working/toybox
 make ARCH=x86 menuconfig
-echo 'completed!'
-echo 'ready to compile for i486!'
-cd ./../../scripts
+echo 'Completed!'
+echo 'Ready to compile for i486!'
+cd ./../../../scripts
 
 exit

--- a/scripts/6.compile.toybox-0.8.10-i486.sh
+++ b/scripts/6.compile.toybox-0.8.10-i486.sh
@@ -1,12 +1,12 @@
 #! /usr/bin/env bash
-echo 'building toybox [i686]'
+echo 'Building toybox [i686]'
 
-cd ./../build/toybox
-echo 'done! Starting to compile...'
+cd ./../build/working/toybox
+echo 'Done! Starting to compile...'
 LDFLAGS=--static CROSS_COMPILE=i486-linux-musl-cross/bin/i486-linux-musl- make ARCH=x86 toybox
-echo 'done!'
+echo 'Done!'
 
-cd ./../scripts
-echo 'completed!'
+cd ../../../scripts
+echo 'Completed!'
 
 exit

--- a/scripts/7.build-dbclient-2022.83-i486.sh
+++ b/scripts/7.build-dbclient-2022.83-i486.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 echo 'building dropbear client [i486]'
 
-cd ./../build/dropbear
+cd ./../build/working/dropbear
 make clean
 ./configure --disable-zlib
 LTM_CFLAGS=-Os LDFLAGS="-Wl --gc-sections --static" CROSS_COMPILE=i486-linux-musl-cross/bin/i486-linux-musl- CFLAGS="-ffunction-sections -fdata-sections" ARCH=ix86
@@ -9,8 +9,8 @@ LTM_CFLAGS=-Os LDFLAGS="-Wl --gc-sections --static" CROSS_COMPILE=i486-linux-mus
 #	Cross-Compilation as per: http://landley.net/toybox/index.html
 make PROGRAMS="dbclient" ARCH=ix86
 #	Making a single binary as per: https://github.com/mkj/dropbear/blob/master/MULTI.md
-mv ./dropbearmulti ./../1440k-fdd
+mv ./dbclient ./../1440k-fdd
 
-cd ./../../scripts
+cd ./../../../scripts
 
 exit

--- a/scripts/8.make.1440k-floppy.image.sh
+++ b/scripts/8.make.1440k-floppy.image.sh
@@ -1,11 +1,21 @@
 #! /usr/bin/env bash
+
+# Don't run yet. The files aren't in the right locations, and we still need to create the rootfs image, and copy the toybox files, I believe.
+#
+# Creating the rootfs image can be based on:
+# echo 'compressing filesystem into xz-compressed cpio initramfs'
+# cd ./../../fdd/fs
+# find . | cpio -H newc -o | xz -9 > ../rootfs.cpio.xz
+# ls -alh
+# echo 'done!'
+# exit
+
 echo 'Creating the 1440kB Floppy Image...'
 
 cd ./../build/1440k-fdd/
 
 echo 'writing blank image file...'
-echo dd if=/dev/zero of=os1337.1440kB.fdd.img bs=1k
-count=1440
+dd if=/dev/zero of=os1337.1440kB.fdd.img bs=1k count=1440
 echo 'done!'
 
 echo 'formatting image with FAT12...'
@@ -17,10 +27,11 @@ syslinux --install os1337.1440kB.fdd.img
 echo 'done!'
 
 echo 'mounting image and installing the OS/1337 into it...'
-sudo mount -o loop floppinux.img /mnt/os1337-fdd
-sudo cp bzImage /mnt
-sudo cp rootfs.cpio.xz /mnt
-sudo cp syslinux.cfg /mnt
+sudo mkdir /mnt/os1337-fdd
+sudo mount -o loop os1337.1440kB.fdd.img /mnt/os1337-fdd
+sudo cp bzImage /mnt/os1337-fdd
+sudo cp rootfs.cpio.xz /mnt/os1337-fdd
+sudo cp syslinux.cfg /mnt/os1337-fdd
 sudo umount /mnt/os1337-fdd
 echo 'done!'
 


### PR DESCRIPTION
This isn't done, which is why it's a draft, but it's got my initial work on the scripts in the scripts directory.

Scripts 0-7 all have been run and seem to work. With 8, rootfs.cpio.xz hasn't actually been generated at any point, and we need to make sure everything's actually copied to the right places and such.

There's also plenty of cleanup that could be done on 0-7. All the version numbers should probably be in variables, and having them all source a new script for helper functions and shared variables wouldn't be a bad idea. There's also probably unused stuff in there, since I added stuff to match bits in other scripts that might just need deleting and such.

It's also probably worth noting that there's code in here where if you have a .config file in the scripts folder, it'll copy that into the linux directory and use that instead of running tinyconfig. That part hasn't been tested. I also created a downloads directory to store all the downloads in (in the code), and a working directory, mostly to avoid clutter, and it checks to see if the file is already there before downloading it.

Allow edits by maintainers is on, so you can modify things. I'm figuring it can be changed from a draft once it actually works, since cleanup can always be done in another pr if needed.